### PR TITLE
[SDLLOG-1041] Bugfix: filter correlation rules

### DIFF
--- a/mpsiemlib/modules/KnowledgeBase.py
+++ b/mpsiemlib/modules/KnowledgeBase.py
@@ -574,7 +574,8 @@ class KnowledgeBase(ModuleInterface, LoggingHandler):
         """
         params = {"filters": {"SiemObjectType": ["Correlation"]}}
         if filters is not None:
-            filters.update(params)
+            filters = filters if 'filters' in filters else {"filters": filters}
+            filters['filters'].update(params['filters'])
         else:
             filters = params
 


### PR DESCRIPTION
Cutsom filter for get_correlation_rules needs to be carefully constructed.
Only field .filters should be updated inside the function.